### PR TITLE
hotfix: adjust font color on built by section

### DIFF
--- a/apps/docs/src/components/landing/built-by.tsx
+++ b/apps/docs/src/components/landing/built-by.tsx
@@ -47,7 +47,7 @@ export default function BuiltBy() {
           )}
 
           {company.description && (
-            <div className="text-black text-lg">{company.description}</div>
+            <div className="text-neutral-950 text-lg">{company.description}</div>
           )}
         </div>
       ))}


### PR DESCRIPTION
This pull request makes a minor visual adjustment to the `BuiltBy` component, ensuring that company descriptions are always displayed in black text for improved readability.