### PR TITLE
fix: release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build packages
         run: |
           pnpm --filter @blen/usmds build
-          pnpm turbo run build --filter=!docs --filter=!usmds-storybook
+          pnpm turbo run build --filter=!docs
 
       - name: Generate registry artifacts
         run: pnpm registry:generate

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
 packages:
   - "apps/*"
-  - "!apps/old_showcase"
   - "packages/*"


### PR DESCRIPTION
This pull request makes small adjustments to the build and workspace configuration, primarily to streamline the build process and update package inclusions.

Build process updates:
* In `.github/workflows/release.yml`, the build step for `usmds-storybook` has been removed from the Turbo build filter, so it will now be included in the build process.

Workspace configuration updates:
* In `pnpm-workspace.yaml`, the exclusion for `apps/old_showcase` has been removed, so this app will now be included in the workspace.