### PR TITLE
fix: worklets bug

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -92,6 +92,7 @@ function withExpo(nextConfig) {
         ...(config.resolve.alias || {}),
         '@/registry': path.resolve(__dirname, '../../packages/registry/src'),
         'react-native$': 'react-native-web',
+        'react-native-reanimated$': path.resolve(__dirname, './src/lib/reanimated-mock.js'),
         'react-native/Libraries/EventEmitter/RCTDeviceEventEmitter$':
           'react-native-web/dist/vendor/react-native/NativeEventEmitter/RCTDeviceEventEmitter',
         'react-native/Libraries/vendor/emitter/EventEmitter$':

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -29,6 +29,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
+    "react-native-reanimated": "~4.1.3",
     "react-native-safe-area-context": "~5.6.1",
     "react-native-web": "^0.21.1"
   },

--- a/apps/docs/src/lib/reanimated-mock.js
+++ b/apps/docs/src/lib/reanimated-mock.js
@@ -1,0 +1,386 @@
+'use strict';
+
+import { Animated as AnimatedRN, Image as ImageRN, Text as TextRN, View as ViewRN } from 'react-native';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const NOOP = () => {};
+const NOOP_FACTORY = () => NOOP;
+const ID = (t) => t;
+const IMMEDIATE_CALLBACK_INVOCATION = (callback) => callback();
+
+const hook = {
+  useAnimatedProps: IMMEDIATE_CALLBACK_INVOCATION,
+  useEvent: (_handler, _eventNames, _rebuild) => NOOP,
+  useSharedValue: (init) => {
+    const value = { value: init };
+    return new Proxy(value, {
+      get(target, prop) {
+        if (prop === 'value') return target.value;
+        if (prop === 'get') return () => target.value;
+        if (prop === 'set') {
+          return (newValue) => {
+            if (typeof newValue === 'function') {
+              target.value = newValue(target.value);
+            } else {
+              target.value = newValue;
+            }
+          };
+        }
+      },
+      set(target, prop, newValue) {
+        if (prop === 'value') {
+          target.value = newValue;
+          return true;
+        }
+        return false;
+      },
+    });
+  },
+  useAnimatedStyle: IMMEDIATE_CALLBACK_INVOCATION,
+  useAnimatedReaction: NOOP,
+  useAnimatedRef: () => ({ current: null }),
+  useAnimatedScrollHandler: NOOP_FACTORY,
+  useDerivedValue: (processor) => {
+    const result = processor();
+    return {
+      value: result,
+      get: () => result,
+    };
+  },
+  useAnimatedSensor: () => ({
+    sensor: {
+      value: { x: 0, y: 0, z: 0, interfaceOrientation: 0, qw: 0, qx: 0, qy: 0, qz: 0, yaw: 0, pitch: 0, roll: 0 },
+    },
+    unregister: NOOP,
+    isAvailable: false,
+    config: { interval: 0, adjustToInterfaceOrientation: false, iosReferenceFrame: 0 },
+  }),
+  useAnimatedKeyboard: () => ({ height: 0, state: 0 }),
+  useScrollViewOffset: () => ({ value: 0 }),
+  useScrollOffset: () => ({ value: 0 }),
+};
+
+const animation = {
+  cancelAnimation: NOOP,
+  withDecay: (_userConfig, callback) => {
+    callback?.(true);
+    return 0;
+  },
+  withDelay: (_delayMs, nextAnimation) => nextAnimation,
+  withRepeat: ID,
+  withSequence: () => 0,
+  withSpring: (toValue, _userConfig, callback) => {
+    callback?.(true);
+    return toValue;
+  },
+  withTiming: (toValue, _userConfig, callback) => {
+    callback?.(true);
+    return toValue;
+  },
+};
+
+const interpolation = {
+  Extrapolation: { CLAMP: 0, EXTEND: 1, IDENTITY: 2 },
+  interpolate: NOOP,
+  clamp: NOOP,
+};
+
+const interpolateColor = {
+  Extrapolate: interpolation.Extrapolation,
+  Extrapolation: interpolation.Extrapolation,
+  ColorSpace: { RGB: 0, HSV: 1 },
+  interpolateColor: NOOP,
+};
+
+const Easing = {
+  Easing: {
+    linear: ID,
+    ease: ID,
+    quad: ID,
+    cubic: ID,
+    poly: ID,
+    sin: ID,
+    circle: ID,
+    exp: ID,
+    elastic: ID,
+    back: ID,
+    bounce: ID,
+    bezier: () => ({ factory: ID }),
+    bezierFn: ID,
+    steps: ID,
+    in: ID,
+    out: ID,
+    inOut: ID,
+  },
+};
+
+const platformFunctions = {
+  measure: () => ({ x: 0, y: 0, width: 0, height: 0, pageX: 0, pageY: 0 }),
+  scrollTo: NOOP,
+};
+
+const Colors = {
+  processColor: (color) => color,
+};
+
+class BaseAnimationMock {
+  duration() { return this; }
+  delay() { return this; }
+  springify() { return this; }
+  damping() { return this; }
+  stiffness() { return this; }
+  withCallback() { return this; }
+  randomDelay() { return this; }
+  withInitialValues() { return this; }
+  easing(_) { return this; }
+  rotate(_) { return this; }
+  mass(_) { return this; }
+  restDisplacementThreshold(_) { return this; }
+  restSpeedThreshold(_) { return this; }
+  overshootClamping(_) { return this; }
+  dampingRatio(_) { return this; }
+  getDelay() { return 0; }
+  getDelayFunction() { return NOOP; }
+  getDuration() { return 300; }
+  getReduceMotion() { return 0; }
+  getAnimationAndConfig() { return [NOOP, {}]; }
+  build() {
+    return () => ({ initialValues: {}, animations: {} });
+  }
+  reduceMotion() { return this; }
+}
+
+const core = {
+  runOnJS: ID,
+  runOnUI: ID,
+  createWorkletRuntime: NOOP,
+  runOnRuntime: NOOP,
+  makeMutable: ID,
+  createSerializable: ID,
+  isReanimated3: () => false,
+  enableLayoutAnimations: NOOP,
+};
+
+const layoutReanimation = {
+  BaseAnimationBuilder: new BaseAnimationMock(),
+  ComplexAnimationBuilder: new BaseAnimationMock(),
+  Keyframe: BaseAnimationMock,
+  FlipInXUp: new BaseAnimationMock(),
+  FlipInYLeft: new BaseAnimationMock(),
+  FlipInXDown: new BaseAnimationMock(),
+  FlipInYRight: new BaseAnimationMock(),
+  FlipInEasyX: new BaseAnimationMock(),
+  FlipInEasyY: new BaseAnimationMock(),
+  FlipOutXUp: new BaseAnimationMock(),
+  FlipOutYLeft: new BaseAnimationMock(),
+  FlipOutXDown: new BaseAnimationMock(),
+  FlipOutYRight: new BaseAnimationMock(),
+  FlipOutEasyX: new BaseAnimationMock(),
+  FlipOutEasyY: new BaseAnimationMock(),
+  StretchInX: new BaseAnimationMock(),
+  StretchInY: new BaseAnimationMock(),
+  StretchOutX: new BaseAnimationMock(),
+  StretchOutY: new BaseAnimationMock(),
+  FadeIn: new BaseAnimationMock(),
+  FadeInRight: new BaseAnimationMock(),
+  FadeInLeft: new BaseAnimationMock(),
+  FadeInUp: new BaseAnimationMock(),
+  FadeInDown: new BaseAnimationMock(),
+  FadeOut: new BaseAnimationMock(),
+  FadeOutRight: new BaseAnimationMock(),
+  FadeOutLeft: new BaseAnimationMock(),
+  FadeOutUp: new BaseAnimationMock(),
+  FadeOutDown: new BaseAnimationMock(),
+  SlideInRight: new BaseAnimationMock(),
+  SlideInLeft: new BaseAnimationMock(),
+  SlideOutRight: new BaseAnimationMock(),
+  SlideOutLeft: new BaseAnimationMock(),
+  SlideInUp: new BaseAnimationMock(),
+  SlideInDown: new BaseAnimationMock(),
+  SlideOutUp: new BaseAnimationMock(),
+  SlideOutDown: new BaseAnimationMock(),
+  ZoomIn: new BaseAnimationMock(),
+  ZoomInRotate: new BaseAnimationMock(),
+  ZoomInLeft: new BaseAnimationMock(),
+  ZoomInRight: new BaseAnimationMock(),
+  ZoomInUp: new BaseAnimationMock(),
+  ZoomInDown: new BaseAnimationMock(),
+  ZoomInEasyUp: new BaseAnimationMock(),
+  ZoomInEasyDown: new BaseAnimationMock(),
+  ZoomOut: new BaseAnimationMock(),
+  ZoomOutRotate: new BaseAnimationMock(),
+  ZoomOutLeft: new BaseAnimationMock(),
+  ZoomOutRight: new BaseAnimationMock(),
+  ZoomOutUp: new BaseAnimationMock(),
+  ZoomOutDown: new BaseAnimationMock(),
+  ZoomOutEasyUp: new BaseAnimationMock(),
+  ZoomOutEasyDown: new BaseAnimationMock(),
+  BounceIn: new BaseAnimationMock(),
+  BounceInDown: new BaseAnimationMock(),
+  BounceInUp: new BaseAnimationMock(),
+  BounceInLeft: new BaseAnimationMock(),
+  BounceInRight: new BaseAnimationMock(),
+  BounceOut: new BaseAnimationMock(),
+  BounceOutDown: new BaseAnimationMock(),
+  BounceOutUp: new BaseAnimationMock(),
+  BounceOutLeft: new BaseAnimationMock(),
+  BounceOutRight: new BaseAnimationMock(),
+  LightSpeedInRight: new BaseAnimationMock(),
+  LightSpeedInLeft: new BaseAnimationMock(),
+  LightSpeedOutRight: new BaseAnimationMock(),
+  LightSpeedOutLeft: new BaseAnimationMock(),
+  PinwheelIn: new BaseAnimationMock(),
+  PinwheelOut: new BaseAnimationMock(),
+  RotateInDownLeft: new BaseAnimationMock(),
+  RotateInDownRight: new BaseAnimationMock(),
+  RotateInUpLeft: new BaseAnimationMock(),
+  RotateInUpRight: new BaseAnimationMock(),
+  RotateOutDownLeft: new BaseAnimationMock(),
+  RotateOutDownRight: new BaseAnimationMock(),
+  RotateOutUpLeft: new BaseAnimationMock(),
+  RotateOutUpRight: new BaseAnimationMock(),
+  RollInLeft: new BaseAnimationMock(),
+  RollInRight: new BaseAnimationMock(),
+  RollOutLeft: new BaseAnimationMock(),
+  RollOutRight: new BaseAnimationMock(),
+  Layout: new BaseAnimationMock(),
+  LinearTransition: new BaseAnimationMock(),
+  FadingTransition: new BaseAnimationMock(),
+  SequencedTransition: new BaseAnimationMock(),
+  JumpingTransition: new BaseAnimationMock(),
+  CurvedTransition: new BaseAnimationMock(),
+  EntryExitTransition: new BaseAnimationMock(),
+};
+
+const LayoutAnimationConfig = ({ children }) => children;
+
+const commonTypes = {
+  SensorType: { ACCELEROMETER: 1, GYROSCOPE: 2, GRAVITY: 3, MAGNETIC_FIELD: 4, ROTATION: 5 },
+  IOSReferenceFrame: { XArbitraryZVertical: 0, XArbitraryCorrectedZVertical: 1, XMagneticNorthZVertical: 2, XTrueNorthZVertical: 3 },
+  InterfaceOrientation: { ROTATION_0: 0, ROTATION_90: 90, ROTATION_180: 180, ROTATION_270: 270 },
+  KeyboardState: { UNKNOWN: 0, OPENING: 1, OPEN: 2, CLOSING: 3, CLOSED: 4 },
+  ReduceMotion: { System: 0, Always: 1, Never: 2 },
+};
+
+const jestUtils = {
+  withReanimatedTimer: (callback) => callback(),
+  advanceAnimationByTime: NOOP,
+  advanceAnimationByFrame: NOOP,
+  setUpTests: NOOP,
+  getAnimatedStyle: () => ({}),
+};
+
+const Animated = {
+  View: ViewRN,
+  Text: TextRN,
+  Image: ImageRN,
+  ScrollView: AnimatedRN.ScrollView,
+  FlatList: AnimatedRN.FlatList,
+  Extrapolate: interpolation.Extrapolation,
+  interpolate: NOOP,
+  interpolateColor: NOOP,
+  clamp: NOOP,
+  createAnimatedComponent: ID,
+  addWhitelistedUIProps: NOOP,
+  addWhitelistedNativeProps: NOOP,
+};
+
+// Extract exports from objects
+const {
+  runOnJS,
+  runOnUI,
+  createWorkletRuntime,
+  runOnRuntime,
+  makeMutable,
+  createSerializable,
+  enableLayoutAnimations,
+} = core;
+
+const {
+  useAnimatedProps,
+  useEvent,
+  useSharedValue,
+  useAnimatedStyle,
+  useAnimatedReaction,
+  useAnimatedRef,
+  useAnimatedScrollHandler,
+  useDerivedValue,
+  useAnimatedSensor,
+  useAnimatedKeyboard,
+  useScrollViewOffset,
+  useScrollOffset,
+} = hook;
+
+const {
+  cancelAnimation,
+  withDecay,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withSpring,
+  withTiming,
+} = animation;
+
+const {
+  FadeIn,
+  FadeInRight,
+  FadeInLeft,
+  FadeInUp,
+  FadeInDown,
+  FadeOut,
+  FadeOutRight,
+  FadeOutLeft,
+  FadeOutUp,
+  FadeOutDown,
+  LinearTransition,
+  Layout,
+} = layoutReanimation;
+
+// Export all individual items
+export default Animated;
+export const reanimatedVersion = '3.0.0-mock';
+export {
+  LayoutAnimationConfig,
+  // Core
+  runOnJS,
+  runOnUI,
+  createWorkletRuntime,
+  runOnRuntime,
+  makeMutable,
+  createSerializable,
+  enableLayoutAnimations,
+  // Hooks
+  useAnimatedProps,
+  useEvent,
+  useSharedValue,
+  useAnimatedStyle,
+  useAnimatedReaction,
+  useAnimatedRef,
+  useAnimatedScrollHandler,
+  useDerivedValue,
+  useAnimatedSensor,
+  useAnimatedKeyboard,
+  useScrollViewOffset,
+  useScrollOffset,
+  // Animations
+  cancelAnimation,
+  withDecay,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withSpring,
+  withTiming,
+  // Layout animations
+  FadeIn,
+  FadeInRight,
+  FadeInLeft,
+  FadeInUp,
+  FadeInDown,
+  FadeOut,
+  FadeOutRight,
+  FadeOutLeft,
+  FadeOutUp,
+  FadeOutDown,
+  LinearTransition,
+  Layout,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       react-native:
         specifier: 0.81.4
         version: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
+      react-native-reanimated:
+        specifier: ~4.1.3
+        version: 4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-safe-area-context:
         specifier: ~5.6.1
         version: 5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -11308,7 +11311,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.18.3
     optionalDependencies:
-      expo-router: 6.0.13(f8ea46937953afba4d5118d3427e3efb)
+      expo-router: 6.0.13(2fbb9b647898031091f4db90b4c614aa)
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -11355,7 +11358,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
       resolve-workspace-root: 2.0.0
-      semver: 7.6.3
+      semver: 7.7.3
       slugify: 1.6.6
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -11523,7 +11526,7 @@ snapshots:
       debug: 4.4.3
       expo: 54.0.15(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(@modelcontextprotocol/sdk@1.20.0)(expo-router@6.0.13)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       resolve-from: 5.0.0
-      semver: 7.6.3
+      semver: 7.7.3
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -13096,7 +13099,7 @@ snapshots:
       metro: 0.83.3
       metro-config: 0.83.3
       metro-core: 0.83.3
-      semver: 7.6.3
+      semver: 7.7.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16117,6 +16120,53 @@ snapshots:
       react-native-is-edge-to-edge: 1.2.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
+
+  expo-router@6.0.13(2fbb9b647898031091f4db90b4c614aa):
+    dependencies:
+      '@expo/metro-runtime': 6.1.2(expo@54.0.15)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@expo/schema-utils': 0.1.7
+      '@radix-ui/react-slot': 1.2.0(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@react-navigation/bottom-tabs': 7.4.8(@react-navigation/native@7.1.18(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native': 7.1.18(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-navigation/native-stack': 7.3.27(@react-navigation/native@7.1.18(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      client-only: 0.0.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      expo: 54.0.15(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(@modelcontextprotocol/sdk@1.20.0)(expo-router@6.0.13)(graphql@16.11.0)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-constants: 18.0.9(expo@54.0.15)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))
+      expo-linking: 8.0.8(expo@54.0.15)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-server: 1.0.2
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.11
+      query-string: 7.1.3
+      react: 19.1.0
+      react-fast-compare: 3.2.2
+      react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
+      react-native-is-edge-to-edge: 1.2.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-safe-area-context: 5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-screens: 4.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      semver: 7.6.3
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.1.0
+      shallowequal: 1.1.0
+      use-latest-callback: 0.2.5(react@19.1.0)
+      vaul: 1.1.2(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+    optionalDependencies:
+      '@react-navigation/drawer': 7.5.9(@react-navigation/native@7.1.18(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-reanimated@4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@testing-library/react-native': 12.9.0(jest@29.7.0(@types/node@24.6.2))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react-test-renderer@19.1.0(react@19.1.0))(react@19.1.0)
+      react-dom: 19.1.0(react@19.1.0)
+      react-native-gesture-handler: 2.28.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-reanimated: 4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-web: 0.21.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-server-dom-webpack: 19.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.15)))
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+      - '@types/react'
+      - '@types/react-dom'
+      - supports-color
+    optional: true
 
   expo-router@6.0.13(f8ea46937953afba4d5118d3427e3efb):
     dependencies:
@@ -19590,7 +19640,7 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0)
       react-native-reanimated: 4.1.3(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
-      semver: 7.6.3
+      semver: 7.7.3
       tailwindcss: 3.4.18(tsx@4.20.6)(yaml@2.8.1)
     optionalDependencies:
       react-native-safe-area-context: 5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -19757,6 +19807,16 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.1.17)(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.17
+
+  react-server-dom-webpack@19.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.15))):
+    dependencies:
+      acorn-loose: 8.5.2
+      neo-async: 2.6.2
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.15))
+      webpack-sources: 3.3.3
+    optional: true
 
   react-server-dom-webpack@19.0.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.102.1):
     dependencies:
@@ -20191,7 +20251,7 @@ snapshots:
 
   semver-diff@5.0.0:
     dependencies:
-      semver: 7.6.3
+      semver: 7.7.3
 
   semver-regex@4.0.5: {}
 
@@ -21260,6 +21320,16 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+    optional: true
 
   vaul@1.1.2(@types/react-dom@19.2.1(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
Summary

  Problem: React Native Reanimated worklets were failing in the Next.js
  browser environment because worklets require a special JavaScript
  runtime that only exists in React Native, not in web browsers.

  Solution: Created a custom Reanimated mock and configured webpack to use
   it for web builds.

  Changes Made

  1. Added dependency (apps/docs/package.json)
    - Installed react-native-reanimated@~4.1.3 in the docs app
  2. Created custom mock (apps/docs/src/lib/reanimated-mock.js)
    - Provides no-op implementations of all Reanimated hooks
  (useAnimatedStyle, useDerivedValue, withTiming, etc.)
    - Exports mock layout animations that won't throw errors
    - Uses regular React Native Web components instead of animated ones
    - Crucially: doesn't import from real Reanimated, preventing worklet
  initialization
  3. Updated webpack config (apps/docs/next.config.mjs:95)
    - Added alias: 'react-native-reanimated$': path.resolve(__dirname, 
  './src/lib/reanimated-mock.js')
    - Redirects all Reanimated imports to the custom mock on web

  Result

  - Worklets errors are eliminated in the browser
  - Components using Reanimated (like Accordion) render without runtime
  errors
  - Animations are gracefully disabled on web (expected behavior)
  - No impact on native React Native builds